### PR TITLE
Removing the 'aws_s3_bucket_acl'

### DIFF
--- a/modules/static_website/main.tf
+++ b/modules/static_website/main.tf
@@ -27,13 +27,29 @@ resource "aws_s3_bucket_public_access_block" "website" {
   restrict_public_buckets = false
 }
 
-resource "aws_s3_bucket_acl" "website" {
+resource "aws_s3_bucket_policy" "allow_s3_public_read" {
+  bucket = aws_s3_bucket.website.id
+  policy = data.aws_iam_policy_document.allow_s3_public_read.json
+
   depends_on = [
+    aws_s3_bucket.website,
     aws_s3_bucket_ownership_controls.website,
     aws_s3_bucket_public_access_block.website,
   ]
-  bucket = aws_s3_bucket.website.id
-  acl    = "public-read"
+
+}
+
+data "aws_iam_policy_document" "allow_s3_public_read" {
+  statement {
+    sid       = "PublicReadGetObject"
+    effect    = "Allow"
+    resources = ["${aws_s3_bucket.website.arn}/*"]
+    actions   = ["s3:GetObject"]
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+  }
 }
 
 resource "aws_s3_bucket_object" "index" {

--- a/s3_website.tf
+++ b/s3_website.tf
@@ -27,13 +27,30 @@ resource "aws_s3_bucket_public_access_block" "website" {
   restrict_public_buckets = false
 }
 
-resource "aws_s3_bucket_acl" "website" {
+
+resource "aws_s3_bucket_policy" "allow_s3_public_read" {
+  bucket = aws_s3_bucket.website.id
+  policy = data.aws_iam_policy_document.allow_s3_public_read.json
+
   depends_on = [
+    aws_s3_bucket.website,
     aws_s3_bucket_ownership_controls.website,
     aws_s3_bucket_public_access_block.website,
   ]
-  bucket = aws_s3_bucket.website.id
-  acl    = "public-read"
+
+}
+
+data "aws_iam_policy_document" "allow_s3_public_read" {
+  statement {
+    sid       = "PublicReadGetObject"
+    effect    = "Allow"
+    resources = ["${aws_s3_bucket.website.arn}/*"]
+    actions   = ["s3:GetObject"]
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+  }
 }
 
 resource "aws_s3_bucket_object" "index" {


### PR DESCRIPTION
- Removing the 'aws_s3_bucket_acl' as per Trello [card](https://trello.com/c/QuRJQlHy/8-content-terraform-courses-update-content-around-s3-acls-as-theyre-old-hat)

- Tested with the TF-next-steps course

- provisioning-v2 workflow for the TF-next-steps course has been updated in the [PR](https://github.com/scalefactory/training-sessions-provisioning-v2/pull/83)

- Academy content for **tf-next-steps** training has been updated in the [PR](https://github.com/scalefactory/training-sessions/pull/511)

